### PR TITLE
Changed user #1 in seed file to be non-gmail user

### DIFF
--- a/web-app/script/demo-seed.js
+++ b/web-app/script/demo-seed.js
@@ -26,7 +26,7 @@ async function seed () {
 
   const users = await Promise.all([
     User.create({
-      email: 'jgore00@gmail.com',
+      email: 'jgore@fullstack.com',
       password: 'context'
     }),
     User.create({


### PR DESCRIPTION
Solving the following issue: "...there’s nothing actually wrong with Google OAuth - the problem started because we changed the seed file main user to have my personal email address, jgore00@gmail.com. Then when I actually tried to login through Google it queried the db for a `googleId`:
```js
User.find({where: {googleId}})
      .then(foundUser => (foundUser
        ? done(null, foundUser)
        : User.create({name, email, googleId})
          .then(createdUser => done(null, createdUser))
      ))
```
Since the user associated with the Gmail account had no `googleId`, the `auth/google` route tried to create the user jgore00@gmail.com, but since we have a `unique` constraint on the `User` model's `email` field, this resulted in an error.

With that said I’ve edited the seed file so that our main user does not have a Gmail address and put in a pull request.